### PR TITLE
fix: mac SIP won't allow moving to /usr/bin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # makefile for alxcalc
 
-BIN_PATH = /usr/bin
+BIN_PATH = /usr/local/bin
 
 DIR = $(HOME)/.alxcalc
 


### PR DESCRIPTION
Fixes System Integrity Protection issue when copying sh file to /usr/bin, copies to /usr/local/bin instead